### PR TITLE
Updated ReadMe for checkpoint submission

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,16 @@
-# Chirpy Starter [![Gem Version](https://img.shields.io/gem/v/jekyll-theme-chirpy)](https://rubygems.org/gems/jekyll-theme-chirpy) [![GitHub license](https://img.shields.io/github/license/cotes2020/chirpy-starter.svg?color=blue)][mit]
+# Energy Cost and HVAC Optimization in Smart Buildings Website
+
+This is the code repository for the Winter 2023 data science project for Energy Cost and HVAC Optimization in Smart Buildings. 
+
+To view the website, please **click the link [here](https://xenonition.github.io/)**.
+
+This was developed to show off results from the code presented [here](https://github.com/ESR76/Capstone-Brick-Modeling). If you'd like to see another visualization of this information, please check out the poster from our poster session [here](https://www.canva.com/design/DAFZKQlLOLo/2ALw0oHRO8qrPj--Q-8huw/view?utm_content=DAFZKQlLOLo&utm_campaign=designshare&utm_medium=link&utm_source=publishsharelink).
+
+Below is the ReadMe corresponding to the starter code we used (the Chirpy starter). This is mostly useful for us as we develop the site further, but you're welcome to read through it as well.
+
+---
+
+## Chirpy Starter [![Gem Version](https://img.shields.io/gem/v/jekyll-theme-chirpy)](https://rubygems.org/gems/jekyll-theme-chirpy) [![GitHub license](https://img.shields.io/github/license/cotes2020/chirpy-starter.svg?color=blue)][mit]
 
 When installing the [**Chirpy**][chirpy] theme through [RubyGems.org][gem], Jekyll can only read files in the folders `/_data`, `/_layouts`, `/_includes`, `/_sass` and `/assets`, as well as a small part of options of the `/_config.yml` file from the theme's gem. If you have ever installed this theme gem, you can use the command `bundle info --path jekyll-theme-chirpy` to locate these files.
 
@@ -16,11 +28,11 @@ To fully use all the features of **Chirpy**, you need to copy the other critical
 
 To save you time, and also in case you lose some files while copying, we extract those files/configurations of the latest version of the **Chirpy** theme and the [CD][CD] workflow to here, so that you can start writing in minutes.
 
-## Prerequisites
+### Prerequisites
 
 Follow the instructions in the [Jekyll Docs](https://jekyllrb.com/docs/installation/) to complete the installation of `Ruby`, `RubyGems`, `Jekyll` and `Bundler`.
 
-## Installation
+### Installation
 
 [**Use this template**][use-template] to generate a brand new repository and name it `<GH_USERNAME>.github.io`, where `GH_USERNAME` represents your GitHub username.
 
@@ -30,11 +42,11 @@ Then clone it to your local machine and run:
 $ bundle
 ```
 
-## Usage
+### Usage
 
 Please see the [theme's docs](https://github.com/cotes2020/jekyll-theme-chirpy#documentation).
 
-## License
+### License
 
 This work is published under [MIT][mit] License.
 


### PR DESCRIPTION
Updated ReadMe to have the website submission link for the checkpoint as stated here: https://dsc-capstone.github.io/assignments/projects/q2/#website

Original ReadMe text was pushed below checkpoint submission relevant materials.